### PR TITLE
feat: add `rows` prop for `FormInputTextarea`

### DIFF
--- a/src/Inputs/FormInputTextarea.vue
+++ b/src/Inputs/FormInputTextarea.vue
@@ -63,7 +63,6 @@ export interface ComponentProps {
 const props = withDefaults(
     defineProps<ComponentProps>(),
     {
-        rows: 2,
         disabled: false,
         renderAsGroup: false,
         readOnly: false

--- a/src/Inputs/FormInputTextarea.vue
+++ b/src/Inputs/FormInputTextarea.vue
@@ -21,6 +21,7 @@
             @update="onUpdate"
             @blur="onBlur"
             :readonly="readOnly"
+            :rows="rows"
         />
         <BFormInvalidFeedback
             v-if="invalid && validation"
@@ -44,6 +45,7 @@ import FormInputFeedbackMessage from './FormInputFeedbackMessage.vue'
 
 export interface ComponentProps {
     label?: string
+    rows?: number
     size?: Size
     validationMessages?: Record<string, any>
     validation?: Validation
@@ -61,6 +63,7 @@ export interface ComponentProps {
 const props = withDefaults(
     defineProps<ComponentProps>(),
     {
+        rows: 2,
         disabled: false,
         renderAsGroup: false,
         readOnly: false


### PR DESCRIPTION
There was no option to controll rows in Textarea