### PR TITLE
date-picker enforce utc

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -9,6 +9,7 @@ export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
+    BButton: typeof import('bootstrap-vue-next')['BButton']
     BFormCheckbox: typeof import('bootstrap-vue-next')['BFormCheckbox']
     BFormCheckboxGroup: typeof import('bootstrap-vue-next')['BFormCheckboxGroup']
     BFormGroup: typeof import('bootstrap-vue-next')['BFormGroup']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tvaliasek/vue-form-inputs",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "MIT",
       "dependencies": {
         "bootstrap-vue-next": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "private": false,
   "files": [
     "src",

--- a/src/App.vue
+++ b/src/App.vue
@@ -105,6 +105,22 @@
                         label="Datepicker input"
                         v-model.trim="dateInput"
                         :validation="v$.dateInput"
+                        enable-time
+                        @blur="(...args: any) => onEvent('datePicker', 'blur', ...args)"
+                        @change="(...args: any) => onEvent('datePicker', 'change', ...args)"
+                        @update="(...args: any) => onEvent('datePicker', 'update', ...args)"
+                    />
+                </InputTester>
+
+                <InputTester
+                    :title="'Date picker input with enforced UTC'"
+                    :input-value="dateInputEnforcedUTC"
+                >
+                    <form-input-date-picker
+                        label="Datepicker input"
+                        v-model.trim="dateInputEnforcedUTC"
+                        enable-time
+                        enforce-utc
                         @blur="(...args: any) => onEvent('datePicker', 'blur', ...args)"
                         @change="(...args: any) => onEvent('datePicker', 'change', ...args)"
                         @update="(...args: any) => onEvent('datePicker', 'update', ...args)"
@@ -163,6 +179,7 @@ const checkboxGroup = ref([])
 const radioGroup = ref(null)
 const dateInput = ref(null)
 const fileInput = ref<File | File[] | undefined | null>(null)
+const dateInputEnforcedUTC = ref(null)
 
 const options = computed(() => [
     {
@@ -212,7 +229,7 @@ const v$ = useVuelidate({
     textInput: {
         required,
         minLength: minLength(4),
-        custom: (value) => {
+        custom: (value: string) => {
             return value === 'custom'
         }
     },

--- a/src/Inputs/FormInputDatePicker.vue
+++ b/src/Inputs/FormInputDatePicker.vue
@@ -21,6 +21,7 @@
             :format="dateFormatter"
             :locale="locale"
             :uid="(id) ? `dtpkr_${id}` : undefined"
+            :utc="enforceUtc ? 'preserve' : false"
             :class="{ 'is-datepicker-invalid': ((invalid !== null) ? invalid : false) }"
         >
             <template #dp-input>
@@ -77,6 +78,7 @@ export interface ComponentProps {
     enableTime?: boolean
     ignoreTimeValidation?: boolean
     dateFormat?: string | ((params: Date | Date[]) => string)
+    enforceUtc?: boolean
 }
 
 const props = withDefaults(
@@ -87,7 +89,8 @@ const props = withDefaults(
         readOnly: false,
         ignoreTimeValidation: true,
         enableTime: false,
-        locale: 'cs-CZ'
+        locale: 'cs-CZ',
+        enforceUtc: false
     }
 )
 
@@ -137,7 +140,7 @@ const displayValue = computed(() => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const value = unref(model)
     if (value instanceof Date) {
-        return unref(dateFormatter)(value)
+        return unref(dateFormatter)(value, unref(props.locale), unref(props.enforceUtc))
     }
     return value
 })

--- a/src/Inputs/datePickerUtils.ts
+++ b/src/Inputs/datePickerUtils.ts
@@ -1,43 +1,15 @@
 export const prefixWithZero = (part: number): string => `${(part < 10) ? '0' : ''}${part}`
 
-export const dateFormat = (input: string | Date): string => {
+export const dateFormat = (input: string | Date, locale: string, enforceUtc: boolean): string => {
     if (input instanceof Date) {
-        return `${input.getDate()}.${input.getMonth() + 1}. ${input.getFullYear()}`
+        return input.toLocaleDateString(locale, { timeZone: enforceUtc ? 'UTC' : undefined })
     }
     return input
 }
 
-export const dateTimeFormat = (input: string | Date): string => {
+export const dateTimeFormat = (input: string | Date, locale: string, enforceUtc: boolean): string => {
     if (input instanceof Date) {
-        const datePart = dateFormat(input)
-        return `${datePart} - ${input.getHours()}:${prefixWithZero(input.getMinutes())}`
+        return input.toLocaleString(locale, { timeZone: enforceUtc ? 'UTC' : undefined })
     }
     return input
-}
-
-export const textToDate = (input: string | Date): Date | null => {
-    if (input instanceof Date) {
-        return input
-    }
-    const parts = `${input}`.replace(/\s/ig, '').split('.')
-    if (parts.length >= 3) {
-        const day = parseInt(parts[0])
-        const month = parseInt(parts[1])
-        const year = parseInt(`${parts[2]}`.substring(0, 4))
-        const timeParts = `${parts[2]}`.substring(4, 5).split(':').map(item => parseInt(item)).filter(item => !isNaN(item))
-
-        if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
-            let date: string | Date = `${year}-${prefixWithZero(month)}-${prefixWithZero(day)}`
-            if (timeParts.length >= 2) {
-                date = `${date}T${prefixWithZero(timeParts[0])}:${prefixWithZero(timeParts[1])}:00.000Z`
-            } else {
-                date = `${date}T00:00:00.000Z`
-            }
-            date = new Date(date)
-            if (date instanceof Date && !isNaN(date.valueOf())) {
-                return date
-            }
-        }
-    }
-    return null
 }


### PR DESCRIPTION
- fix: fix missing invalid feedback on date pickers
- feat: FormInputDatePicker add UTC with enforceUtc, use toLocale(Date)String for default formatter
