### PR TITLE
FormInput autocomplete prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "private": false,
   "files": [
     "src",

--- a/src/Inputs/FormInput.vue
+++ b/src/Inputs/FormInput.vue
@@ -23,6 +23,7 @@
                 :placeholder="placeholder"
                 :readonly="readOnly"
                 :lazy-formatter="(lazyFormatter === false ? undefined : true)"
+                :autocomplete="autocomplete"
                 @change="onChange"
                 @update="onUpdate"
                 @blur="onBlur"
@@ -42,6 +43,7 @@
             :placeholder="placeholder"
             :readonly="readOnly"
             :lazy-formatter="(lazyFormatter === false ? undefined : true)"
+            :autocomplete="autocomplete"
             @change="onChange"
             @update="onUpdate"
             @blur="onBlur"
@@ -82,6 +84,7 @@ export interface ComponentProps {
     readOnly?: boolean
     showAsRequired?: boolean
     lazyFormatter?: boolean
+    autocomplete?: string
 }
 
 const props = withDefaults(


### PR DESCRIPTION
- fix: fix missing invalid feedback on date pickers
- feat: FormInputDatePicker add UTC with enforceUtc, use toLocale(Date)String for default formatter
- refactor: remove unnecessary format prop, remove seconds from dateForm functions
- fix: changed slots for input group proper styling
- 3.4.0
- 3.5.0
- fix: invalid / valid state for form groups
- 3.5.1
- chore: bump @vuepic/vue-datepicker version to ^5.3.0
- chore: autogenerated definition of BButton in components.d.ts
- chore: version bump
- 3.5.2
- feat: optional lazy formatter prop
- 3.5.3
- feat: optional lazy formatter prop
- fix: forgotten template string in input label
- 3.5.4
- feat: FormInput autocomplete prop
