### PR TITLE
master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tvaliasek/vue-form-inputs",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "^10.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": false,
   "files": [
     "src",

--- a/src/Inputs/Bootstrap/VfiFormRadio.vue
+++ b/src/Inputs/Bootstrap/VfiFormRadio.vue
@@ -21,6 +21,7 @@
             :id="id"
             :disabled="disabled ?? undefined"
             :name="name"
+            :checked="model === value ? true : undefined"
             :aria-invalid="props.state === false ? 'true' : 'false'"
             @input="onInput"
         />

--- a/src/Inputs/FormInputRadioGroup.vue
+++ b/src/Inputs/FormInputRadioGroup.vue
@@ -17,7 +17,7 @@
             :state="(invalid !== null) ? !invalid : undefined"
             :disabled="disabled || readOnly"
             :options="options"
-            :stacked="stacked"
+            :inline="!stacked"
             @change="onChange"
             @update="onUpdate"
             @blur="onBlur"


### PR DESCRIPTION
- fix: fix missing invalid feedback on date pickers
- feat: FormInputDatePicker add UTC with enforceUtc, use toLocale(Date)String for default formatter
- refactor: remove unnecessary format prop, remove seconds from dateForm functions
- fix: changed slots for input group proper styling
- 3.4.0
- 3.5.0
- fix: invalid / valid state for form groups
- 3.5.1
- chore: bump @vuepic/vue-datepicker version to ^5.3.0
- chore: autogenerated definition of BButton in components.d.ts
- chore: version bump
- 3.5.2
- feat: optional lazy formatter prop
- 3.5.3
- feat: optional lazy formatter prop
- fix: forgotten template string in input label
- 3.5.4
- feat: FormInput autocomplete prop
- chore: changed build
- feat: FormInputDatePicker add prop defaultTime
- gitfix
- feat: dropped bootstrap-vue-next dependency
- chore: refactored build process
- chore: export types
- fix: FormInputTextarea v-model breaking reactivity because of missing v-bind:value of inner component
- fix: empty labels on checkboxes
- 4.0.3
- feat: changed vue18i integration to injection
- 5.0.0
- fix: FormInputRadioGroup stacked prop
- fix: VfiFormRadio checked default value
- 5.0.1
