### PR TITLE
master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "private": false,
   "files": [
     "src",

--- a/src/Inputs/Bootstrap/Utils/normalizeInput.ts
+++ b/src/Inputs/Bootstrap/Utils/normalizeInput.ts
@@ -1,6 +1,6 @@
 export default (
     value: string | number | null,
-    modelModifiers: Record<'number' | 'lazy' | 'trim', true | undefined>
+    modelModifiers: Partial<Record<'number' | 'lazy' | 'trim', true | undefined>>
 ) => {
     if (value === null) {
         return

--- a/src/Inputs/Bootstrap/VfiFormInput.vue
+++ b/src/Inputs/Bootstrap/VfiFormInput.vue
@@ -47,7 +47,7 @@ const props = withDefaults(defineProps<{
     lazyFormatter?: boolean
     ariaInvalid?: boolean | 'grammar' | 'spelling'
     modelValue?: string | number | null
-    modelModifiers?: Record<'number' | 'lazy' | 'trim', boolean | undefined>
+    modelModifiers?: Partial<Record<'number' | 'lazy' | 'trim', boolean | undefined>>
 }>(), {
     disabled: false,
     plaintext: false,

--- a/src/Inputs/Bootstrap/VfiFormTextarea.vue
+++ b/src/Inputs/Bootstrap/VfiFormTextarea.vue
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<{
     lazyFormatter?: boolean
     ariaInvalid?: boolean | 'grammar' | 'spelling'
     modelValue?: string | number | null
-    modelModifiers?: Record<'number' | 'lazy' | 'trim', boolean | undefined>
+    modelModifiers?: Partial<Record<'number' | 'lazy' | 'trim', boolean | undefined>>
     rows?: number | string
 }>(), {
     disabled: false,

--- a/src/Inputs/Composables/useFormInput.ts
+++ b/src/Inputs/Composables/useFormInput.ts
@@ -11,7 +11,7 @@ export default (
         disabled?: boolean
         ariaInvalid?: boolean | 'grammar' | 'spelling'
         state?: boolean | null
-        modelModifiers?: Record<'number' | 'lazy' | 'trim', boolean | undefined>
+        modelModifiers?: Partial<Record<'number' | 'lazy' | 'trim', boolean | undefined>>
     }>,
     modelValue: Ref<string | number | null>
 ): {

--- a/src/Inputs/FormInput.vue
+++ b/src/Inputs/FormInput.vue
@@ -101,7 +101,7 @@ export interface ComponentProps {
     lazyFormatter?: boolean
     autocomplete?: string
     name?: string
-    modelModifiers?: Record<'number' | 'lazy' | 'trim', boolean | undefined>
+    modelModifiers?: Partial<Record<'number' | 'lazy' | 'trim', boolean | undefined>>
 }
 
 const props = withDefaults(

--- a/src/Inputs/FormInputTextarea.vue
+++ b/src/Inputs/FormInputTextarea.vue
@@ -63,7 +63,7 @@ export interface ComponentProps {
     readOnly?: boolean
     showAsRequired?: boolean
     lazyFormatter?: boolean
-    modelModifiers?: Record<'number' | 'lazy' | 'trim', boolean | undefined>
+    modelModifiers?: Partial<Record<'number' | 'lazy' | 'trim', boolean | undefined>>
 }
 
 const props = withDefaults(


### PR DESCRIPTION
- **fix: fix missing invalid feedback on date pickers**
- **feat: FormInputDatePicker add UTC with enforceUtc, use toLocale(Date)String for default formatter**
- **refactor: remove unnecessary format prop, remove seconds from dateForm functions**
- **fix: changed slots for input group proper styling**
- **3.4.0**
- **3.5.0**
- **fix: invalid / valid state for form groups**
- **3.5.1**
- **chore: bump @vuepic/vue-datepicker version to ^5.3.0**
- **chore: autogenerated definition of BButton in components.d.ts**
- **chore: version bump**
- **3.5.2**
- **feat: optional lazy formatter prop**
- **3.5.3**
- **feat: optional lazy formatter prop**
- **fix: forgotten template string in input label**
- **3.5.4**
- **feat: FormInput autocomplete prop**
- **chore: changed build**
- **feat: FormInputDatePicker add prop defaultTime**
- **gitfix**
- **feat: dropped bootstrap-vue-next dependency**
- **chore: refactored build process**
- **chore: export types**
- **fix: FormInputTextarea v-model breaking reactivity because of missing v-bind:value of inner component**
- **fix: empty labels on checkboxes**
- **4.0.3**
- **feat: changed vue18i integration to injection**
- **5.0.0**
- **fix: FormInputRadioGroup stacked prop**
- **fix: VfiFormRadio checked default value**
- **5.0.1**
- **5.0.2**
- **fix: refactored internal useId to official vue useId composable**
- **5.0.3**
- **fix: better typing on validation prop**
- **fix: better typing on validation prop**
- **chore: modelModifiers partial type**
