### PR TITLE
master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tvaliasek/vue-form-inputs",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "^12.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvaliasek/vue-form-inputs",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "private": false,
   "files": [
     "src",

--- a/src/Inputs/Bootstrap/VfiFormCheckboxGroup.vue
+++ b/src/Inputs/Bootstrap/VfiFormCheckboxGroup.vue
@@ -17,7 +17,7 @@
             :size="size"
             :state="state"
             :switch="props.switch"
-            :disabled="disabled"
+            :disabled="disabled || option.disabled"
             :name="`${name}-${index}`"
             :inline="inline"
             :value="option.value"

--- a/src/Inputs/Bootstrap/VfiFormRadioGroup.vue
+++ b/src/Inputs/Bootstrap/VfiFormRadioGroup.vue
@@ -16,7 +16,7 @@
             :label="option.text"
             :size="size"
             :state="state"
-            :disabled="disabled"
+            :disabled="disabled || option.disabled"
             :name="name ?? toValue(computedId)"
             :inline="inline"
             :value="option.value"


### PR DESCRIPTION
- **fix: fix missing invalid feedback on date pickers**
- **feat: FormInputDatePicker add UTC with enforceUtc, use toLocale(Date)String for default formatter**
- **refactor: remove unnecessary format prop, remove seconds from dateForm functions**
- **fix: changed slots for input group proper styling**
- **3.4.0**
- **3.5.0**
- **fix: invalid / valid state for form groups**
- **3.5.1**
- **chore: bump @vuepic/vue-datepicker version to ^5.3.0**
- **chore: autogenerated definition of BButton in components.d.ts**
- **chore: version bump**
- **3.5.2**
- **feat: optional lazy formatter prop**
- **3.5.3**
- **feat: optional lazy formatter prop**
- **fix: forgotten template string in input label**
- **3.5.4**
- **feat: FormInput autocomplete prop**
- **chore: changed build**
- **feat: FormInputDatePicker add prop defaultTime**
- **gitfix**
- **feat: dropped bootstrap-vue-next dependency**
- **chore: refactored build process**
- **chore: export types**
- **fix: FormInputTextarea v-model breaking reactivity because of missing v-bind:value of inner component**
- **fix: empty labels on checkboxes**
- **4.0.3**
- **feat: changed vue18i integration to injection**
- **5.0.0**
- **fix: FormInputRadioGroup stacked prop**
- **fix: VfiFormRadio checked default value**
- **5.0.1**
- **5.0.2**
- **fix: refactored internal useId to official vue useId composable**
- **5.0.3**
- **fix: better typing on validation prop**
- **fix: better typing on validation prop**
- **chore: modelModifiers partial type**
- **5.0.6**
- **chore: gitignore, bump**
- **fix: pass disabled in option for radio and checkbox**
