### PR TITLE
Add focus event to input handling

### DIFF
--- a/src/Inputs/Composables/useInput.ts
+++ b/src/Inputs/Composables/useInput.ts
@@ -24,7 +24,7 @@ export function useInput(props: Record<string, any>, $emit: (event: any, ...args
         return null
     })
 
-    const onEvent = (eventName: 'change' | 'update' | 'blur') => {
+    const onEvent = (eventName: 'change' | 'update' | 'blur' | 'focus') => {
         return (eventData: unknown) => {
             $emit(eventName, eventData)
         }
@@ -33,6 +33,7 @@ export function useInput(props: Record<string, any>, $emit: (event: any, ...args
     const onChange = onEvent('change')
     const onUpdate = onEvent('update')
     const onBlur = onEvent('blur')
+    const onFocus = onEvent('focus')
 
     const formatValue = function (value: string, event?: Event): string {
         const formatter = unref(props.formatter)
@@ -49,6 +50,7 @@ export function useInput(props: Record<string, any>, $emit: (event: any, ...args
         onUpdate,
         onBlur,
         onEvent,
+        onFocus,
         formatValue
     }
 }

--- a/src/Inputs/FormInput.vue
+++ b/src/Inputs/FormInput.vue
@@ -48,6 +48,7 @@
                 @change="onChange"
                 @update="onUpdate"
                 @blur="onBlur"
+                @focus="onFocus"
             />
             <slot name="append"></slot>
         </div>
@@ -70,6 +71,7 @@
             @change="onChange"
             @update="onUpdate"
             @blur="onBlur"
+            @focus="onFocus"
         />
         <template
             #invalid-feedback
@@ -127,7 +129,7 @@ const props = withDefaults(
 
 const computedId = computed(() => (props?.id) ? props.id : useId())
 
-const $emit = defineEmits(['update:modelValue', 'change', 'update', 'blur'])
+const $emit = defineEmits(['update:modelValue', 'change', 'update', 'blur', 'focus'])
 
 type modelType = string | number | undefined
 const model = computed({
@@ -157,6 +159,7 @@ const {
     onUpdate,
     onChange,
     onBlur,
+    onFocus,
     formatValue
 } = useInput(props, $emit)
 </script>


### PR DESCRIPTION
Introduce a focus event to the input handling logic, allowing for better interaction tracking. This change enhances the event emission capabilities of the input component.